### PR TITLE
Fixing incorrect plugin names/links

### DIFF
--- a/src/plugins/ardura/Interleaf/1.0.0.yaml
+++ b/src/plugins/ardura/Interleaf/1.0.0.yaml
@@ -1,7 +1,7 @@
 ---
-name: Scrollscope
+name: Interleaf
 author: Ardura
-homepage: https://github.com/ardura/Scrollscope
+homepage: https://github.com/ardura/Interleaf
 description: A simple scrolling oscilloscope in rust with multichannel inputs and an analyzer
 date: 2024-07-12T07:00:00.000Z
 license: gpl-3.0

--- a/src/plugins/ardura/Subhoofer/2.2.1.yaml
+++ b/src/plugins/ardura/Subhoofer/2.2.1.yaml
@@ -1,7 +1,7 @@
 ---
-name: Scrollscope
+name: Subhoofer
 author: Ardura
-homepage: https://github.com/ardura/Scrollscope
+homepage: https://github.com/ardura/Subhoofer
 description: A simple scrolling oscilloscope in rust with multichannel inputs and an analyzer
 date: 2024-07-12T07:00:00.000Z
 license: gpl-3.0


### PR DESCRIPTION
Accidentally did these the first time - this update fixes them with proper names and homepage link
![image](https://github.com/user-attachments/assets/7c1596e4-9051-47e8-9379-6b66b9718b1a)
![image](https://github.com/user-attachments/assets/cb846126-0c6b-4603-a7b9-fc08c0d3848b)
